### PR TITLE
fix: expose Traefik dashboard port and remove TLS annotations

### DIFF
--- a/apps/workloads/traefik/app.yaml
+++ b/apps/workloads/traefik/app.yaml
@@ -33,8 +33,6 @@ spec:
         ingressRoute:
           dashboard:
             enabled: true
-            annotations:
-              traefik.ingress.kubernetes.io/router.tls: "true"
 
         # Ports configuration
         ports:
@@ -53,7 +51,7 @@ spec:
           traefik:
             port: 9000
             expose:
-              default: false
+              default: true
             exposedPort: 9000
 
         # Enable cert-manager integration


### PR DESCRIPTION
- Remove problematic TLS annotations from dashboard IngressRoute
- Expose dashboard port 9000 in LoadBalancer service
- Clean up old conflicting traefik namespace (done manually)